### PR TITLE
fix:the scrollEnabled property being affected when sliding left and right in nested scrollview

### DIFF
--- a/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
+++ b/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
@@ -162,6 +162,7 @@ namespace rnoh {
         }
         else{
             this->m_nativeLock = false;
+            if(!this->m_scrollEnabled) return;
             this->getLocalRootArkUINode().setDisableSwipe(false);
         }
     }


### PR DESCRIPTION
# Summary

-  fix:the scrollEnabled property being affected when sliding left and right in nested scrollview

Close: #30 

## Test Plan

- 在tabview里面配置scrollview列表，并设置scrollEnabled属性为false，左右滑动禁止
- 已验证ok


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
