### PR TITLE
fix:修复滑动误触引起的浮标拖拽异常问题

### DIFF
--- a/harmony/pager_view/src/main/cpp/SwiperNode.cpp
+++ b/harmony/pager_view/src/main/cpp/SwiperNode.cpp
@@ -126,6 +126,7 @@ namespace rnoh {
             m_swiperNodeDelegate->setClickTap(false);
             this->m_interceptSendOffset = false;
             this->m_gestureSwipe = true;
+            m_swiperNodeDelegate->setGestureStatus(this->m_gestureSwipe);
             facebook::react::RNCViewPagerEventEmitter::OnPageScrollStateChanged event = {
                 facebook::react::RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Dragging};
             m_swiperNodeDelegate->onPageScrollStateChanged(event);

--- a/harmony/pager_view/src/main/cpp/SwiperNode.h
+++ b/harmony/pager_view/src/main/cpp/SwiperNode.h
@@ -44,11 +44,7 @@ namespace rnoh {
     
         virtual bool getNativeLock(){
           return false;
-        }; 
-    
-        virtual int getLayoutMetricsWidth(){
-          return 0;   
-        }
+        };
     
         virtual void setKeyboardDismiss(){};
     

--- a/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
+++ b/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
@@ -136,10 +136,6 @@ namespace rnoh {
         return result;
     }
 
-    int ViewPagerComponentInstance::getLayoutMetricsWidth(){
-       return this->m_layoutMetrics.frame.size.width;
-    }
-
     void ViewPagerComponentInstance::setKeyboardDismiss() {
         DLOG(INFO) << "ViewPagerComponentInstance::setKeyboardDismiss: " << this->m_keyboardDismissMode ;
         if (this->m_keyboardDismissMode != "on-drag") return;
@@ -174,7 +170,7 @@ namespace rnoh {
 
     bool ViewPagerComponentInstance::isHandlingTouches() const {
         DLOG(INFO) << "ViewPagerComponentInstance::isHandlingTouches:" << this->m_gestureStatus;
-        return this->m_gestureStatus ? true : false;
+        return this->m_gestureStatus;
     }
 
     void ViewPagerComponentInstance::regsiterGestureEvent() {
@@ -186,10 +182,7 @@ namespace rnoh {
             PanActionCallBack *panActionCallBack = (PanActionCallBack *)extraParam;
             ArkUI_GestureEventActionType actionType = OH_ArkUI_GestureEvent_GetActionType(event);
 
-            if (actionType == GESTURE_EVENT_ACTION_UPDATE) {
-                DLOG(INFO) << "ViewPagerComponentInstance::regsiterGestureEvent GESTURE_EVENT_ACTION_UPDATE";
-                panActionCallBack->swiperNodeDelegate->setGestureStatus(true);
-            } else if (actionType == GESTURE_EVENT_ACTION_END) {
+            if (actionType == GESTURE_EVENT_ACTION_END) {
                 DLOG(INFO) << "ViewPagerComponentInstance::regsiterGestureEvent GESTURE_EVENT_ACTION_END";
                 panActionCallBack->swiperNodeDelegate->setGestureStatus(false);
             }

--- a/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.h
+++ b/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.h
@@ -80,8 +80,6 @@ namespace rnoh {
     
         bool getNativeLock() override;
     
-        int getLayoutMetricsWidth() override;
-    
         void setKeyboardDismiss() override;
     
        void onNativeResponderBlockChange(bool isBlocked) override;


### PR DESCRIPTION
# Summary

 - 修复滑动误触引起的浮标拖拽异常问题
 - Close: #32 

## Test Plan

1.打开vmall首页，拖拽浮标
2.可以正常拖拽
3.已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
