### PR TITLE
fix:修复滑动误触引起的无法点击问题

### DIFF
--- a/harmony/pager_view/src/main/cpp/SwiperNode.cpp
+++ b/harmony/pager_view/src/main/cpp/SwiperNode.cpp
@@ -109,6 +109,7 @@ namespace rnoh {
                 facebook::react::RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Idle};
             m_swiperNodeDelegate->onPageScrollStateChanged(pageScrollStateChange);
             this->m_gestureSwipe = false;
+            m_swiperNodeDelegate->setGestureStatus(this->m_gestureSwipe);
         } else if (eventType == ArkUI_NodeEventType::NODE_SWIPER_EVENT_ON_CHANGE) {
             DLOG(INFO) << "onNodeEvent-->NODE_SWIPER_EVENT_ON_CHANGE: " << eventArgs[0].i32;
             if (!this->m_pageSelectNotify) {


### PR DESCRIPTION
# Summary

- fix:修复滑动误触引起的无法点击问题
- Close: #35 

## Test Plan

- 打开vmall首页
- 从第一个页面滑动到第二个页面再滑回来
- 点击第一个页面的控件，可以正常点击
- 已验证ok


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)