### PR TITLE
fix:修复左右滑动页面后再设置scrollEnabled属性不生效问题

### DIFF
--- a/harmony/pager_view/src/main/cpp/SwiperNode.cpp
+++ b/harmony/pager_view/src/main/cpp/SwiperNode.cpp
@@ -124,7 +124,6 @@ namespace rnoh {
             this->m_pageSelectNotify = false;
         } else if (eventType == ArkUI_NodeEventType::NODE_SWIPER_EVENT_ON_GESTURE_SWIPE) {
             DLOG(INFO) << "onNodeEvent-->NODE_SWIPER_EVENT_ON_GESTURE_SWIPE";
-            m_swiperNodeDelegate->setNeedSetProps(false);
             m_swiperNodeDelegate->setClickTap(false);
             this->m_interceptSendOffset = false;
             this->m_gestureSwipe = true;

--- a/harmony/pager_view/src/main/cpp/SwiperNode.h
+++ b/harmony/pager_view/src/main/cpp/SwiperNode.h
@@ -57,8 +57,6 @@ namespace rnoh {
         virtual bool getClickTap() { return false; };
     
         virtual void sendEventAnimationsPageScroll(facebook::react::RNCViewPagerEventEmitter::OnPageScroll pageScroll){};
-    
-        virtual void setNeedSetProps(bool needSetProps){};
     };
 
     class SwiperNode : public ArkUINode {

--- a/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
+++ b/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
@@ -49,16 +49,18 @@ void ViewPagerComponentInstance::onChildRemoved(ComponentInstance::Shared const 
 
 void ViewPagerComponentInstance::onPropsChanged(SharedConcreteProps const &props) {
     super::onPropsChanged(props);
-    DLOG(INFO) << "ViewPagerComponentInstance::m_needSetProps: " << this->m_needSetProps
-               << " initialPage:" << props->initialPage;
-    if (!this->m_needSetProps) {
-        this->m_needSetProps = true;
-        return;
-    }
+    DLOG(INFO) << "ViewPagerComponentInstance::onPropsChanged: initialPage:" << props->initialPage 
+               << " scrollEnabled:" << props->scrollEnabled << " orientation:" << facebook::react::toString(props->orientation)
+               << " keyboardDismissMode:" << facebook::react::toString(props->keyboardDismissMode) << " layoutDirection:" << facebook::react::toString(props->layoutDirection)
+               << " pageMargin:" << props->pageMargin << " offscreenPageLimit:" << props->offscreenPageLimit
+               << " m_isInitialPage:" << this->m_isInitialPage;
     this->m_scrollEnabled = props->scrollEnabled;
     this->m_pageIndex = props->initialPage;
     this->m_keyboardDismissMode = facebook::react::toString(props->keyboardDismissMode);
-    this->getLocalRootArkUINode().setIndexNoAnimation(props->initialPage);
+    if(this->m_isInitialPage) {
+       this->getLocalRootArkUINode().setIndexNoAnimation(props->initialPage);
+       this->m_isInitialPage = false; 
+    }
     this->getLocalRootArkUINode().setVertical(facebook::react::toString(props->orientation));
     this->getLocalRootArkUINode().setDirection(facebook::react::toString(props->layoutDirection));
     this->getLocalRootArkUINode().setItemSpace(props->pageMargin);
@@ -111,11 +113,9 @@ void ViewPagerComponentInstance::handleCommand(std::string const &commandName, f
     } else if (commandName == "setPage" && args.isArray() && args.size() == 1) {
         this->m_clickTap = true;
         DLOG(INFO) << "handleCommand-->setPage: " << args[0];
-        this->m_needSetProps = false;
         this->getLocalRootArkUINode().setIndex(args[0].asInt());
     } else if (commandName == "setPageWithoutAnimation" && args.isArray() && args.size() == 1) {
         DLOG(INFO) << "handleCommand-->setPageWithoutAnimation: " << args[0];
-        this->m_needSetProps = false;
         this->m_clickTap = true;
         this->getLocalRootArkUINode().setIndexNoAnimation(args[0].asInt());
     }
@@ -217,8 +217,5 @@ void ViewPagerComponentInstance::sendEventAnimationsPageScroll(
                    << " offset " << pageScroll.offset;
     }
 }
-
-
-void ViewPagerComponentInstance::setNeedSetProps(bool needSetProps) { this->m_needSetProps = needSetProps; }
 
 } // namespace rnoh

--- a/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.h
+++ b/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.h
@@ -43,14 +43,14 @@ private:
     bool m_nativeLock = false;
 
     std::string m_keyboardDismissMode;
-
-    bool m_needSetProps = true;
-
+    
     bool m_gestureStatus = false;
 
     bool m_clickTap = false;
 
     bool m_gestureSwipe = false;
+    
+    bool m_isInitialPage = true;
 
     struct PanActionCallBack {
         SwiperNodeDelegate *swiperNodeDelegate;
@@ -98,7 +98,5 @@ public:
     void regsiterGestureEvent();
 
     void sendEventAnimationsPageScroll(facebook::react::RNCViewPagerEventEmitter::OnPageScroll pageScroll) override;
-
-    void setNeedSetProps(bool needSetProps) override;
 };
 } // namespace rnoh


### PR DESCRIPTION
# Summary

- fix:修复左右滑动页面后再设置scrollEnabled属性不生效问题
- Close: #45 

## Test Plan

- 验证pageview所有testcase是否正常
- 验证issues中的示例是否正常
- 已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

