### PR TITLE
fix:修复react-native-paper-view三方库的paperview放在scrollview中使用，在滚动的时候会直接闪退的问题

### DIFF
--- a/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
+++ b/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
@@ -123,7 +123,7 @@ bool ViewPagerComponentInstance::getNativeLock() { return this->m_nativeLock; }
 
 std::vector<TouchTarget::Shared> ViewPagerComponentInstance::getTouchTargetChildren() {
     auto children = getChildren();
-    std::vector<TouchTarget::Shared> result(1);
+    std::vector<TouchTarget::Shared> result;
     result.push_back(children.at(m_pageIndex));
     return result;
 }


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。t -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
- Closed: #51
- react-native-pager-view库中的PagerView组件放在ScrollView中使用，在滚动的时候会直接闪退 
- 这个功能是什么？（如果适用）
- 您是如何实现解决方案的？
- 这个更改影响了库的哪些部分？

## Test Plan
展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
## Checklist
<!-- 检查项, 请自行排查并打钩, 通过: [X] -->
- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)
