### PR TITLE
fix:修复onPageSelected回调时机问题

### DIFF
--- a/harmony/pager_view/src/main/cpp/SwiperNode.cpp
+++ b/harmony/pager_view/src/main/cpp/SwiperNode.cpp
@@ -90,7 +90,6 @@ namespace rnoh {
             DLOG(INFO) << "onNodeEvent-->NODE_SWIPER_EVENT_ON_ANIMATION_START m_currentIndex:" << eventArgs[0].i32
                        << " m_targetIndex:" << this->m_targetIndex;
             this->m_pageSelectNotify = true;
-            m_swiperNodeDelegate->onPageSelected(this->m_targetIndex);
             m_swiperNodeDelegate->setKeyboardDismiss();
             facebook::react::RNCViewPagerEventEmitter::OnPageScrollStateChanged event = {
                 facebook::react::RNCViewPagerEventEmitter::OnPageScrollStateChangedPageScrollState::Settling};
@@ -114,8 +113,8 @@ namespace rnoh {
             m_swiperNodeDelegate->setGestureStatus(this->m_gestureSwipe);
         } else if (eventType == ArkUI_NodeEventType::NODE_SWIPER_EVENT_ON_CHANGE) {
             DLOG(INFO) << "onNodeEvent-->NODE_SWIPER_EVENT_ON_CHANGE: " << eventArgs[0].i32;
+            m_swiperNodeDelegate->onPageSelected(eventArgs[0].i32);
             if (!this->m_pageSelectNotify) {
-                m_swiperNodeDelegate->onPageSelected(eventArgs[0].i32);
                 facebook::react::RNCViewPagerEventEmitter::OnPageScroll m_onPageScroll = {
                     static_cast<double>(eventArgs[0].i32), 0};
                 m_swiperNodeDelegate->onPageScroll(m_onPageScroll);


### PR DESCRIPTION
# Summary

- fix:修复onPageSelected回调时机问题
- Close: #54 

## Test Plan

- 测试用例onPageSelected属性，滑动页面到中间，再回弹回来
- 已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

