### PR TITLE
fix: 修改页面切换后的点击穿透问题

### DIFF
--- a/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
+++ b/harmony/pager_view/src/main/cpp/ViewPagerComponentInstance.cpp
@@ -55,7 +55,7 @@ void ViewPagerComponentInstance::onPropsChanged(SharedConcreteProps const &props
                << " pageMargin:" << props->pageMargin << " offscreenPageLimit:" << props->offscreenPageLimit
                << " overdrag:" << props->overdrag << " overScrollMode:" << facebook::react::toString(props->overScrollMode);
     this->m_scrollEnabled = props->scrollEnabled;
-    this->m_pageIndex = props->initialPage;
+    if(this->m_isInitialPage) this->m_pageIndex = props->initialPage;
     this->m_keyboardDismissMode = facebook::react::toString(props->keyboardDismissMode);
     this->getLocalRootArkUINode().setVertical(facebook::react::toString(props->orientation));
     this->getLocalRootArkUINode().setDirection(facebook::react::toString(props->layoutDirection));


### PR DESCRIPTION
fix: 修改页面切换后的点击穿透问题
此处的m_pageIndex应该只在页面第一次进入时被更新成props->initialPage，
通过标志位判断解决此处值被多次更新的问题，解决react-native-scrollable-tab-view将其作为页面容器时页面切换后的点击穿透问题