### PR TITLE
fix: 修改嵌套滑动时父子组件无法联动响应的问题

### DIFF
--- a/harmony/pager_view/src/main/cpp/SwiperNode.cpp
+++ b/harmony/pager_view/src/main/cpp/SwiperNode.cpp
@@ -42,6 +42,10 @@ namespace rnoh {
             m_nodeHandle, NODE_SWIPER_EVENT_ON_CONTENT_DID_SCROLL, NODE_SWIPER_EVENT_ON_CONTENT_DID_SCROLL, this));
         maybeThrow(NativeNodeApi::getInstance()->registerNodeEvent(
             m_nodeHandle, NODE_EVENT_ON_APPEAR, NODE_EVENT_ON_APPEAR, this));
+        // 开启嵌套滑动时的父子联动响应
+        ArkUI_NumberValue indexValue[] = {{.i32 = m_swiperNestedScrollMode}};
+        ArkUI_AttributeItem indexItem = {indexValue, sizeof(indexValue) / sizeof(ArkUI_NumberValue)};
+        maybeThrow(NativeNodeApi::getInstance()->setAttribute(m_nodeHandle, NODE_SWIPER_NESTED_SCROLL, &indexItem));
     }
 
 

--- a/harmony/pager_view/src/main/cpp/SwiperNode.h
+++ b/harmony/pager_view/src/main/cpp/SwiperNode.h
@@ -26,6 +26,7 @@
 
 #include "RNOH/arkui/ArkUINode.h"
 #include "generated/react/renderer/components/react_native_pager_view/EventEmitters.h"
+#include <arkui/native_type.h>
 
 namespace rnoh {
 
@@ -81,6 +82,7 @@ namespace rnoh {
         std::chrono::high_resolution_clock::time_point animationEnd;
         bool m_interceptSendOffset = false;
         std::map<void*,ArkUI_NodeHandle> m_nodeHandleMap;
+        ArkUI_SwiperNestedScrollMode m_swiperNestedScrollMode = ARKUI_SWIPER_NESTED_SRCOLL_SELF_FIRST;
     public:
         SwiperNode();
     


### PR DESCRIPTION
fix: 修改嵌套滑动时父子组件无法联动响应的问题
内部swiper的嵌套滑动模式NODE_SWIPER_NESTED_SCROLL的默认值为ARKUI_SWIPER_NESTED_SRCOLL_SELF_ONLY，当滑到子PagerView边缘时，仍然只滑动自己;
该模式无法父子联动，将其值改为枚举值ARKUI_SWIPER_NESTED_SRCOLL_SELF_FIRST，即可实现父子联动响应，滑到子PagerView边缘时，响应父PagerView的滑动